### PR TITLE
fix (timeslider): update web version and fix reference

### DIFF
--- a/libraries/timeslider/package.json
+++ b/libraries/timeslider/package.json
@@ -7,10 +7,7 @@
         "start": "vertigis-web-sdk start"
     },
     "dependencies": {
-        "@arcgis/core": "~4.28.6",
-        "@vertigis/arcgis-extensions": "^45.2.0",
-        "@vertigis/viewer-spec": "^57.2.0",
-        "@vertigis/web": "^5.29.0",
+        "@vertigis/web": "^5.36.0",
         "tslib": "^2.6.2"
     },
     "devDependencies": {

--- a/libraries/timeslider/src/components/TimeSlider/TimeSliderModel.ts
+++ b/libraries/timeslider/src/components/TimeSlider/TimeSliderModel.ts
@@ -1,6 +1,6 @@
-import TimeExtent from "@arcgis/core/TimeExtent";
 import type WebMap from "@arcgis/core/WebMap";
 import type FeatureLayer from "@arcgis/core/layers/FeatureLayer";
+import TimeExtent from "@arcgis/core/time/TimeExtent";
 import type EsriTimeSlider from "@arcgis/core/widgets/TimeSlider";
 import { ItemType } from "@vertigis/arcgis-extensions/ItemType";
 import type { MapModel } from "@vertigis/web/mapping/MapModel";
@@ -182,7 +182,7 @@ export default class TimeSliderModel extends ComponentModelBase<TimeSliderModelP
 
     private readonly _updateWidgetFromWebMapTimeSlider = async (
         widget: EsriTimeSlider,
-        timeSlider: __esri.WebMapTimeSlider,
+        timeSlider: __esri.TimeSlider,
         map: WebMap
     ): Promise<void> => {
         let timeExtentOption: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,7 +5,16 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@arcgis/core@npm:4.28.10, @arcgis/core@npm:~4.28.6":
+"@arcgis/components-utils@npm:4.33.0-next.158, @arcgis/components-utils@npm:^4.33.0-next.121":
+  version: 4.33.0-next.158
+  resolution: "@arcgis/components-utils@npm:4.33.0-next.158"
+  dependencies:
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/9b17201ccb0b97e2afdafb4679769f789fa06114ed0fc6fe3697c09a556b94159c255abedcf59ebd4fde97ae631097a86604ee464a5686d17849f04ac1c308ab
+  languageName: node
+  linkType: hard
+
+"@arcgis/core@npm:4.28.10":
   version: 4.28.10
   resolution: "@arcgis/core@npm:4.28.10"
   dependencies:
@@ -18,6 +27,35 @@ __metadata:
     luxon: "npm:~3.4.3"
     sortablejs: "npm:~1.15.0"
   checksum: 10c0/8a214c9590c0f80ed61dbd3c8b7f783f1d7f5f277d896ba1a5d866ad8285ab2ec240c7800430cdae24e531b31698c99960aad9e1f4bc970516946207eddf39ae
+  languageName: node
+  linkType: hard
+
+"@arcgis/core@npm:4.32.10":
+  version: 4.32.10
+  resolution: "@arcgis/core@npm:4.32.10"
+  dependencies:
+    "@esri/arcgis-html-sanitizer": "npm:~4.1.0"
+    "@esri/calcite-components": "npm:^3.0.3"
+    "@vaadin/grid": "npm:~24.6.4"
+    "@zip.js/zip.js": "npm:~2.7.57"
+    luxon: "npm:~3.5.0"
+    marked: "npm:~15.0.6"
+  checksum: 10c0/0f887ec8c670059e39bcad08ba9f34a600e436173ba6ba4abd7bd589b8a4ab218d1270c1484c03166bf8f919c77fbf4100f074b33f072a7a6762fb3097b1c039
+  languageName: node
+  linkType: hard
+
+"@arcgis/lumina@npm:^4.33.0-next.121":
+  version: 4.33.0-next.158
+  resolution: "@arcgis/lumina@npm:4.33.0-next.158"
+  dependencies:
+    "@arcgis/components-utils": "npm:4.33.0-next.158"
+    "@lit-labs/ssr": "npm:^3.2.2"
+    "@lit-labs/ssr-client": "npm:^1.1.7"
+    "@lit/context": "npm:^1.1.5"
+    csstype: "npm:^3.1.3"
+    lit: "npm:^3.3.0"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/380aedc803e7aa74b45b1a689381e2c73e1c4da36784d50e803cbda942a7bf68d8e4cb00bab7781f4ad63a8a990dc4dd7948e2211c3d57bcf306ff762c3f19d7
   languageName: node
   linkType: hard
 
@@ -56,6 +94,13 @@ __metadata:
   dependencies:
     regenerator-runtime: "npm:^0.14.0"
   checksum: 10c0/b6fa3ec61a53402f3c1d75f4d808f48b35e0dfae0ec8e2bb5c6fc79fb95935da75766e0ca534d0f1c84871f6ae0d2ebdd950727cfadb745a2cdbef13faef5513
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.25.7, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.27.1":
+  version: 7.27.6
+  resolution: "@babel/runtime@npm:7.27.6"
+  checksum: 10c0/89726be83f356f511dcdb74d3ea4d873a5f0cf0017d4530cb53aa27380c01ca102d573eff8b8b77815e624b1f8c24e7f0311834ad4fb632c90a770fda00bd4c8
   languageName: node
   linkType: hard
 
@@ -614,10 +659,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/cache@npm:^11.13.5":
+  version: 11.14.0
+  resolution: "@emotion/cache@npm:11.14.0"
+  dependencies:
+    "@emotion/memoize": "npm:^0.9.0"
+    "@emotion/sheet": "npm:^1.4.0"
+    "@emotion/utils": "npm:^1.4.2"
+    "@emotion/weak-memoize": "npm:^0.4.0"
+    stylis: "npm:4.2.0"
+  checksum: 10c0/3fa3e7a431ab6f8a47c67132a00ac8358f428c1b6c8421d4b20de9df7c18e95eec04a5a6ff5a68908f98d3280044f247b4965ac63df8302d2c94dba718769724
+  languageName: node
+  linkType: hard
+
+"@emotion/hash@npm:^0.9.2":
+  version: 0.9.2
+  resolution: "@emotion/hash@npm:0.9.2"
+  checksum: 10c0/0dc254561a3cc0a06a10bbce7f6a997883fd240c8c1928b93713f803a2e9153a257a488537012efe89dbe1246f2abfe2add62cdb3471a13d67137fcb808e81c2
+  languageName: node
+  linkType: hard
+
 "@emotion/memoize@npm:^0.8.1":
   version: 0.8.1
   resolution: "@emotion/memoize@npm:0.8.1"
   checksum: 10c0/dffed372fc3b9fa2ba411e76af22b6bb686fb0cb07694fdfaa6dd2baeb0d5e4968c1a7caa472bfcf06a5997d5e7c7d16b90e993f9a6ffae79a2c3dbdc76dfe78
+  languageName: node
+  linkType: hard
+
+"@emotion/memoize@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "@emotion/memoize@npm:0.9.0"
+  checksum: 10c0/13f474a9201c7f88b543e6ea42f55c04fb2fdc05e6c5a3108aced2f7e7aa7eda7794c56bba02985a46d8aaa914fcdde238727a98341a96e2aec750d372dadd15
+  languageName: node
+  linkType: hard
+
+"@emotion/serialize@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "@emotion/serialize@npm:1.3.3"
+  dependencies:
+    "@emotion/hash": "npm:^0.9.2"
+    "@emotion/memoize": "npm:^0.9.0"
+    "@emotion/unitless": "npm:^0.10.0"
+    "@emotion/utils": "npm:^1.4.2"
+    csstype: "npm:^3.0.2"
+  checksum: 10c0/b28cb7de59de382021de2b26c0c94ebbfb16967a1b969a56fdb6408465a8993df243bfbd66430badaa6800e1834724e84895f5a6a9d97d0d224de3d77852acb4
   languageName: node
   linkType: hard
 
@@ -628,6 +713,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/sheet@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@emotion/sheet@npm:1.4.0"
+  checksum: 10c0/3ca72d1650a07d2fbb7e382761b130b4a887dcd04e6574b2d51ce578791240150d7072a9bcb4161933abbcd1e38b243a6fb4464a7fe991d700c17aa66bb5acc7
+  languageName: node
+  linkType: hard
+
+"@emotion/unitless@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "@emotion/unitless@npm:0.10.0"
+  checksum: 10c0/150943192727b7650eb9a6851a98034ddb58a8b6958b37546080f794696141c3760966ac695ab9af97efe10178690987aee4791f9f0ad1ff76783cdca83c1d49
+  languageName: node
+  linkType: hard
+
 "@emotion/utils@npm:^1.2.1":
   version: 1.2.1
   resolution: "@emotion/utils@npm:1.2.1"
@@ -635,10 +734,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/utils@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "@emotion/utils@npm:1.4.2"
+  checksum: 10c0/7d0010bf60a2a8c1a033b6431469de4c80e47aeb8fd856a17c1d1f76bbc3a03161a34aeaa78803566e29681ca551e7bf9994b68e9c5f5c796159923e44f78d9a
+  languageName: node
+  linkType: hard
+
 "@emotion/weak-memoize@npm:^0.3.1":
   version: 0.3.1
   resolution: "@emotion/weak-memoize@npm:0.3.1"
   checksum: 10c0/ed514b3cb94bbacece4ac2450d98898066c0a0698bdeda256e312405ca53634cb83c75889b25cd8bbbe185c80f4c05a1f0a0091e1875460ba6be61d0334f0b8a
+  languageName: node
+  linkType: hard
+
+"@emotion/weak-memoize@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@emotion/weak-memoize@npm:0.4.0"
+  checksum: 10c0/64376af11f1266042d03b3305c30b7502e6084868e33327e944b539091a472f089db307af69240f7188f8bc6b319276fd7b141a36613f1160d73d12a60f6ca1a
   languageName: node
   linkType: hard
 
@@ -693,6 +806,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esri/arcgis-html-sanitizer@npm:~4.1.0":
+  version: 4.1.0
+  resolution: "@esri/arcgis-html-sanitizer@npm:4.1.0"
+  dependencies:
+    xss: "npm:1.0.13"
+  checksum: 10c0/c6b132f562831dc09c5059ec7c857f0d9d0ad8b5142a6bb98ffeaeb3805aa7c04f98dbe1d1964973475b98f86e4ede97c2a2fe594e46352998d91dd52817bf75
+  languageName: node
+  linkType: hard
+
 "@esri/calcite-colors@npm:~6.1.0":
   version: 6.1.0
   resolution: "@esri/calcite-colors@npm:6.1.0"
@@ -718,12 +840,53 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esri/calcite-components@npm:^3.0.3":
+  version: 3.2.1
+  resolution: "@esri/calcite-components@npm:3.2.1"
+  dependencies:
+    "@arcgis/components-utils": "npm:^4.33.0-next.121"
+    "@arcgis/lumina": "npm:^4.33.0-next.121"
+    "@esri/calcite-ui-icons": "npm:4.2.0"
+    "@floating-ui/dom": "npm:^1.6.12"
+    "@floating-ui/utils": "npm:^0.2.8"
+    "@types/sortablejs": "npm:^1.15.8"
+    color: "npm:^5.0.0"
+    composed-offset-position: "npm:^0.0.6"
+    dayjs: "npm:^1.11.13"
+    focus-trap: "npm:^7.6.2"
+    interactjs: "npm:^1.10.27"
+    lodash-es: "npm:^4.17.21"
+    sortablejs: "npm:^1.15.6"
+    timezone-groups: "npm:^0.10.4"
+    type-fest: "npm:^4.30.1"
+  checksum: 10c0/56c58b9f4801b3731d98d4a032c8d12eb3c1f04748e9955f3bbed03fb0625bd55e204c71274bc2d3df8c94bcf326dee3f69255f410182517ecba66e705e45b37
+  languageName: node
+  linkType: hard
+
+"@esri/calcite-ui-icons@npm:4.2.0":
+  version: 4.2.0
+  resolution: "@esri/calcite-ui-icons@npm:4.2.0"
+  bin:
+    spriter: bin/spriter.js
+  checksum: 10c0/d72532ecd61531727a452ab839a76a95b16318ad55e9eee9e86961e535e0e75e8308ddac75128f8b893ce796962c2284bb258307afa1f81d77b238661281ca97
+  languageName: node
+  linkType: hard
+
 "@floating-ui/core@npm:^1.0.0, @floating-ui/core@npm:^1.4.2":
   version: 1.6.2
   resolution: "@floating-ui/core@npm:1.6.2"
   dependencies:
     "@floating-ui/utils": "npm:^0.2.0"
   checksum: 10c0/db2621dc682e7f043d6f118d087ae6a6bfdacf40b26ede561760dd53548c16e2e7c59031e013e37283801fa307b55e6de65bf3b316b96a054e4a6a7cb937c59e
+  languageName: node
+  linkType: hard
+
+"@floating-ui/core@npm:^1.7.1":
+  version: 1.7.1
+  resolution: "@floating-ui/core@npm:1.7.1"
+  dependencies:
+    "@floating-ui/utils": "npm:^0.2.9"
+  checksum: 10c0/40df1e1dd8a2bad6f70c1ee163f0e151c456f52b9b98a38488d88720b2be72ccd631501a66f8369f96d2e8ad1c4250936b6fd4243e3a99833f2d008ee6afec18
   languageName: node
   linkType: hard
 
@@ -744,6 +907,16 @@ __metadata:
     "@floating-ui/core": "npm:^1.0.0"
     "@floating-ui/utils": "npm:^0.2.0"
   checksum: 10c0/ebdc14806f786e60df8e7cc2c30bf9cd4d75fe734f06d755588bbdef2f60d0a0f21dffb14abdc58dea96e5577e2e366feca6d66ba962018efd1bc91a3ece4526
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.6.12":
+  version: 1.7.1
+  resolution: "@floating-ui/dom@npm:1.7.1"
+  dependencies:
+    "@floating-ui/core": "npm:^1.7.1"
+    "@floating-ui/utils": "npm:^0.2.9"
+  checksum: 10c0/33b0e892f4c50ce568169cd58793ff5e3bc1e72ee007237d73b9458d4475e1e5f5a4b3f9e6752422d5f5ac902bc0c135ca7dc0a23c6df187fd9d28dc34cdceed
   languageName: node
   linkType: hard
 
@@ -770,6 +943,13 @@ __metadata:
   version: 0.2.2
   resolution: "@floating-ui/utils@npm:0.2.2"
   checksum: 10c0/b2becdcafdf395af1641348da0031ff1eaad2bc60c22e14bd3abad4acfe2c8401e03097173d89a2f646a99b75819a78ef21ebb2572cab0042a56dd654b0065cd
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.8, @floating-ui/utils@npm:^0.2.9":
+  version: 0.2.9
+  resolution: "@floating-ui/utils@npm:0.2.9"
+  checksum: 10c0/48bbed10f91cb7863a796cc0d0e917c78d11aeb89f98d03fc38d79e7eb792224a79f538ed8a2d5d5584511d4ca6354ef35f1712659fd569868e342df4398ad6f
   languageName: node
   linkType: hard
 
@@ -804,6 +984,13 @@ __metadata:
   peerDependencies:
     react: "*"
   checksum: 10c0/133518adf91010704b716e7671fc28bcc3c461dc4f4a56ad3a73a955b9993dfaa22494579e9377247fd3318baebe8e4ae7962c01bffeaca0044722c09baa9d73
+  languageName: node
+  linkType: hard
+
+"@interactjs/types@npm:1.10.27":
+  version: 1.10.27
+  resolution: "@interactjs/types@npm:1.10.27"
+  checksum: 10c0/767afe37cd932ed248712dc0aa9c912b18af1104ec26829d655daaeef57d13c8e9e973c9f59e4be978d66fe7e86b77f58dec4688bb2e5d38b838d5a38cb27cf4
   languageName: node
   linkType: hard
 
@@ -880,6 +1067,61 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lit-labs/ssr-client@npm:^1.1.7":
+  version: 1.1.7
+  resolution: "@lit-labs/ssr-client@npm:1.1.7"
+  dependencies:
+    "@lit/reactive-element": "npm:^2.0.4"
+    lit: "npm:^3.1.2"
+    lit-html: "npm:^3.1.2"
+  checksum: 10c0/0bef5b1040f01c5f77999c6641f26d33656972a523df5b8389dd901056af2db6e3f4e4377bee446ff97829ff1c268949a0d78522fe4f8c9ef8594d08fa66fed0
+  languageName: node
+  linkType: hard
+
+"@lit-labs/ssr-dom-shim@npm:^1.2.0, @lit-labs/ssr-dom-shim@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@lit-labs/ssr-dom-shim@npm:1.3.0"
+  checksum: 10c0/743a9b295ef2f186712f08883da553c9990be291409615309c99aa4946cfe440a184e4213c790c24505c80beb86b9cfecf10b5fb30ce17c83698f8424f48678d
+  languageName: node
+  linkType: hard
+
+"@lit-labs/ssr@npm:^3.2.2":
+  version: 3.3.1
+  resolution: "@lit-labs/ssr@npm:3.3.1"
+  dependencies:
+    "@lit-labs/ssr-client": "npm:^1.1.7"
+    "@lit-labs/ssr-dom-shim": "npm:^1.3.0"
+    "@lit/reactive-element": "npm:^2.0.4"
+    "@parse5/tools": "npm:^0.3.0"
+    "@types/node": "npm:^16.0.0"
+    enhanced-resolve: "npm:^5.10.0"
+    lit: "npm:^3.1.2"
+    lit-element: "npm:^4.0.4"
+    lit-html: "npm:^3.1.2"
+    node-fetch: "npm:^3.2.8"
+    parse5: "npm:^7.1.1"
+  checksum: 10c0/2e7bd9c1840816b98bd56dbc2f2ffc840b32aa1466ac2a380775d7cb399ca5e8e94b134a98e2edfe210f0c4d5743718aa980231d7b546db8cab5e2d6c4630461
+  languageName: node
+  linkType: hard
+
+"@lit/context@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "@lit/context@npm:1.1.5"
+  dependencies:
+    "@lit/reactive-element": "npm:^1.6.2 || ^2.1.0"
+  checksum: 10c0/16ab105c8fa32db9407199ee5d0ef3751946490946bcdbbd6fe87ab7e09dbce1e00a58c46638340958e4520b69406b3b797ead00017c68db9b268d30c5eda5c3
+  languageName: node
+  linkType: hard
+
+"@lit/reactive-element@npm:^1.6.2 || ^2.1.0, @lit/reactive-element@npm:^2.0.4, @lit/reactive-element@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@lit/reactive-element@npm:2.1.0"
+  dependencies:
+    "@lit-labs/ssr-dom-shim": "npm:^1.2.0"
+  checksum: 10c0/3cd61c4e7cc8effeb2c246d5dada8fbe0a730e9e0dd488eb38c91a4f63b773e3b7f86f8384051677298e73de470c7ca6b5634df3ca190b307f8bb8e0d51bb91c
+  languageName: node
+  linkType: hard
+
 "@mui/base@npm:5.0.0-beta.25":
   version: 5.0.0-beta.25
   resolution: "@mui/base@npm:5.0.0-beta.25"
@@ -931,6 +1173,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/core-downloads-tracker@npm:^6.4.12":
+  version: 6.4.12
+  resolution: "@mui/core-downloads-tracker@npm:6.4.12"
+  checksum: 10c0/c0fa3ee1c3d6b69a3474e58d943ee84167810e6e40652edee35c1096580e254fad5df531c153513a9f16ee6981c10bcad712252cd9740dda5ce9ddeb93bd710a
+  languageName: node
+  linkType: hard
+
 "@mui/icons-material@npm:5.14.19":
   version: 5.14.19
   resolution: "@mui/icons-material@npm:5.14.19"
@@ -944,6 +1193,22 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/1af1a14622795dae1b999b49dc27d8d9f32344ccd3bc73a3b9dbce3d8d7ad43e6aa93e100a58ae423c9404fcb91dbdeb7758bd94f5f4614a4843f649645a42a1
+  languageName: node
+  linkType: hard
+
+"@mui/icons-material@npm:^6.4.0":
+  version: 6.4.12
+  resolution: "@mui/icons-material@npm:6.4.12"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+  peerDependencies:
+    "@mui/material": ^6.4.12
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/794929c57bd190347faa966e5e54640c63a56335d7008f75575c3555fc32e37b25302290b00ca2916e20992c1ace70a269b54132ab0932a5cc0906a9b6b9668e
   languageName: node
   linkType: hard
 
@@ -980,6 +1245,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/material@npm:^6.4.0":
+  version: 6.4.12
+  resolution: "@mui/material@npm:6.4.12"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/core-downloads-tracker": "npm:^6.4.12"
+    "@mui/system": "npm:^6.4.12"
+    "@mui/types": "npm:~7.2.24"
+    "@mui/utils": "npm:^6.4.9"
+    "@popperjs/core": "npm:^2.11.8"
+    "@types/react-transition-group": "npm:^4.4.12"
+    clsx: "npm:^2.1.1"
+    csstype: "npm:^3.1.3"
+    prop-types: "npm:^15.8.1"
+    react-is: "npm:^19.0.0"
+    react-transition-group: "npm:^4.4.5"
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@mui/material-pigment-css": ^6.4.12
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@mui/material-pigment-css":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10c0/cac0be1f6a6caffccbb11e47910f81f13b9431fda57fc22be36e13b336c4f15f855a02ffa3681befb3ec358812ae9caa0cfc144c07de67a799bc367c607f6539
+  languageName: node
+  linkType: hard
+
 "@mui/private-theming@npm:^5.15.20":
   version: 5.15.20
   resolution: "@mui/private-theming@npm:5.15.20"
@@ -994,6 +1295,23 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/d6707ef884769a58a9dac23328138cd2dbb3dbdcfbf46beae406638628a77b2975aaf787f863143ae97ea2d5f6eca8d0ff929f2159f3f9b58bcedb2e01c7bce6
+  languageName: node
+  linkType: hard
+
+"@mui/private-theming@npm:^6.4.9":
+  version: 6.4.9
+  resolution: "@mui/private-theming@npm:6.4.9"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/utils": "npm:^6.4.9"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/3b198fad085b9ce5092cb2ad2aceee5f6a643f68f4fb1469d0748615490b8b9228179a6564be9c6784aa6f1f42a9afe61f1ad5ce0af56858e9bb58d36472e339
   languageName: node
   linkType: hard
 
@@ -1015,6 +1333,29 @@ __metadata:
     "@emotion/styled":
       optional: true
   checksum: 10c0/0d262ea0b3c117f865af1cd52b992592c24432e491b35e712159bb49adfd776ee9a532abbc4ab08889f308e75d30082a0fee809119d5d61a82b3277212655319
+  languageName: node
+  linkType: hard
+
+"@mui/styled-engine@npm:^6.4.11":
+  version: 6.4.11
+  resolution: "@mui/styled-engine@npm:6.4.11"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@emotion/cache": "npm:^11.13.5"
+    "@emotion/serialize": "npm:^1.3.3"
+    "@emotion/sheet": "npm:^1.4.0"
+    csstype: "npm:^3.1.3"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@emotion/react": ^11.4.1
+    "@emotion/styled": ^11.3.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+  checksum: 10c0/332ff6c32e7bfb34e9cd8a3d8d4abb13deaeea3216fb6d1441d8d154c615a76d594595cc34076bc0911f7f4784042a7fe0a83bf1924e78040935fa7242ee5a70
   languageName: node
   linkType: hard
 
@@ -1046,6 +1387,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/system@npm:^6.4.12":
+  version: 6.4.12
+  resolution: "@mui/system@npm:6.4.12"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/private-theming": "npm:^6.4.9"
+    "@mui/styled-engine": "npm:^6.4.11"
+    "@mui/types": "npm:~7.2.24"
+    "@mui/utils": "npm:^6.4.9"
+    clsx: "npm:^2.1.1"
+    csstype: "npm:^3.1.3"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10c0/502ab620caccb59c3acae9376534e706ace38d136c10e254c958f0b7931743fe693ffd1b5c493a9fdfe27aa29ff37867652cfc61595ceb725038df94b37f6f5e
+  languageName: node
+  linkType: hard
+
 "@mui/types@npm:^7.2.10, @mui/types@npm:^7.2.14, @mui/types@npm:^7.2.14-dev.20240529-082515-213b5e33ab":
   version: 7.2.14
   resolution: "@mui/types@npm:7.2.14"
@@ -1055,6 +1424,32 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/d4e0a9fce4bddfb5e0b7b6be1b15b591df33bb90ef0087e4bd5fe85f00f62776c7ed0e4698e7fb43213e1f04064aac1695b53ca52aaeaee7dbba248a792bdd1e
+  languageName: node
+  linkType: hard
+
+"@mui/types@npm:^7.4.3":
+  version: 7.4.3
+  resolution: "@mui/types@npm:7.4.3"
+  dependencies:
+    "@babel/runtime": "npm:^7.27.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/8078ed0c63211377af4cf244e0b8a94d15748253139a330f6c7b983b755a57fa89bdba5d8b9ca4c30944b1567115eab3cbb9b9869c14489b0ad3249e858c9fa1
+  languageName: node
+  linkType: hard
+
+"@mui/types@npm:~7.2.24":
+  version: 7.2.24
+  resolution: "@mui/types@npm:7.2.24"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/7756339cae70e9b684c4311924e4e3882f908552b69c434b4d13faf2f5908ce72fe889a31890257c5ad42a085207be7c1661981dfc683293e90ac6dfac3759d0
   languageName: node
   linkType: hard
 
@@ -1076,6 +1471,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/utils@npm:^5.16.6 || ^6.0.0 || ^7.0.0":
+  version: 7.1.1
+  resolution: "@mui/utils@npm:7.1.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.27.1"
+    "@mui/types": "npm:^7.4.3"
+    "@types/prop-types": "npm:^15.7.14"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    react-is: "npm:^19.1.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/d2563c4be785a94d55d32df7e51be530bb56a21ffbf4d1ca084c51a8b598ad7ee6d8bb30dd4171691c3b669eea6d8da07280aedd8d96fc539cfd0e0e5b9a48a1
+  languageName: node
+  linkType: hard
+
 "@mui/utils@npm:^6.0.0-dev.20240529-082515-213b5e33ab":
   version: 6.0.0-dev.20240529-082515-213b5e33ab
   resolution: "@mui/utils@npm:6.0.0-dev.20240529-082515-213b5e33ab"
@@ -1091,6 +1506,26 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/6fbd5d874936d818e9c8ae595b9111da11422e1b4d3ce973779acdf34431f01f27fbbe175ca5912c4f4f2c7f1b10b98a5cb571cf8da92d5bb46d43fe0811ff85
+  languageName: node
+  linkType: hard
+
+"@mui/utils@npm:^6.4.9":
+  version: 6.4.9
+  resolution: "@mui/utils@npm:6.4.9"
+  dependencies:
+    "@babel/runtime": "npm:^7.26.0"
+    "@mui/types": "npm:~7.2.24"
+    "@types/prop-types": "npm:^15.7.14"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    react-is: "npm:^19.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/27122262bc24d31e8906e3133f3f6e6c858733802019e0e9ec6dedf632ca46287ab3735c9da6be7a7e0b4f043ced9b8f36b5b21bfef1d96ecfa5d150ea458508
   languageName: node
   linkType: hard
 
@@ -1115,6 +1550,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/x-data-grid-pro@npm:^7.24.0":
+  version: 7.29.6
+  resolution: "@mui/x-data-grid-pro@npm:7.29.6"
+  dependencies:
+    "@babel/runtime": "npm:^7.25.7"
+    "@mui/utils": "npm:^5.16.6 || ^6.0.0 || ^7.0.0"
+    "@mui/x-data-grid": "npm:7.29.6"
+    "@mui/x-internals": "npm:7.29.0"
+    "@mui/x-license": "npm:7.29.1"
+    "@types/format-util": "npm:^1.0.4"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    reselect: "npm:^5.1.1"
+  peerDependencies:
+    "@emotion/react": ^11.9.0
+    "@emotion/styled": ^11.8.1
+    "@mui/material": ^5.15.14 || ^6.0.0 || ^7.0.0
+    "@mui/system": ^5.15.14 || ^6.0.0 || ^7.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+  checksum: 10c0/2c971f409a92c15f52cd3da2860ae8cd214ada434dbb4e0b6236b9e3aabe00547e9f99acdbd98ca1b88205f347d019f24f2b5db5ce19ab216566bbc1a7e27704
+  languageName: node
+  linkType: hard
+
 "@mui/x-data-grid@npm:5.17.26":
   version: 5.17.26
   resolution: "@mui/x-data-grid@npm:5.17.26"
@@ -1130,6 +1594,33 @@ __metadata:
     react: ^17.0.2 || ^18.0.0
     react-dom: ^17.0.2 || ^18.0.0
   checksum: 10c0/cf9d1bde0a6ada18227d3ecfe570b398f2be99aa37465c0c58d31ac36ba42d6a65255e636db58a60721ce6752e5dbe1af05529be89926c4fb435f5805690663b
+  languageName: node
+  linkType: hard
+
+"@mui/x-data-grid@npm:7.29.6":
+  version: 7.29.6
+  resolution: "@mui/x-data-grid@npm:7.29.6"
+  dependencies:
+    "@babel/runtime": "npm:^7.25.7"
+    "@mui/utils": "npm:^5.16.6 || ^6.0.0 || ^7.0.0"
+    "@mui/x-internals": "npm:7.29.0"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    reselect: "npm:^5.1.1"
+    use-sync-external-store: "npm:^1.0.0"
+  peerDependencies:
+    "@emotion/react": ^11.9.0
+    "@emotion/styled": ^11.8.1
+    "@mui/material": ^5.15.14 || ^6.0.0 || ^7.0.0
+    "@mui/system": ^5.15.14 || ^6.0.0 || ^7.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+  checksum: 10c0/593368435563c3f24042e98f68cc96394aa9c55f7455b5613f69198143f498301b4e4a3e929fd63734a0c64f5b6617a6147330d367cc4df83785c332c1bc1d3c
   languageName: node
   linkType: hard
 
@@ -1168,6 +1659,55 @@ __metadata:
     moment:
       optional: true
   checksum: 10c0/df6244ebfd9d19b375bf42b112d8fd3f69d0d9597f92bcc8934183be3b33aa7797026f141609e0468b0e562a2ea82655dc1abd16e0fecc5c7f8983f2dde4576c
+  languageName: node
+  linkType: hard
+
+"@mui/x-date-pickers-pro@npm:^7.24.0":
+  version: 7.29.4
+  resolution: "@mui/x-date-pickers-pro@npm:7.29.4"
+  dependencies:
+    "@babel/runtime": "npm:^7.25.7"
+    "@mui/utils": "npm:^5.16.6 || ^6.0.0 || ^7.0.0"
+    "@mui/x-date-pickers": "npm:7.29.4"
+    "@mui/x-internals": "npm:7.29.0"
+    "@mui/x-license": "npm:7.29.1"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    react-transition-group: "npm:^4.4.5"
+  peerDependencies:
+    "@emotion/react": ^11.9.0
+    "@emotion/styled": ^11.8.1
+    "@mui/material": ^5.15.14 || ^6.0.0 || ^7.0.0
+    "@mui/system": ^5.15.14 || ^6.0.0 || ^7.0.0
+    date-fns: ^2.25.0 || ^3.2.0 || ^4.0.0
+    date-fns-jalali: ^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0
+    dayjs: ^1.10.7
+    luxon: ^3.0.2
+    moment: ^2.29.4
+    moment-hijri: ^2.1.2 || ^3.0.0
+    moment-jalaali: ^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    date-fns:
+      optional: true
+    date-fns-jalali:
+      optional: true
+    dayjs:
+      optional: true
+    luxon:
+      optional: true
+    moment:
+      optional: true
+    moment-hijri:
+      optional: true
+    moment-jalaali:
+      optional: true
+  checksum: 10c0/b190a5f77038e6afe419f335453036a2c86d45f498abdd8a69ed79df6fc5223c4f7265c3d4470369b1347825b7a615e64ea0375ae6efff6f13e5894f7e764b29
   languageName: node
   linkType: hard
 
@@ -1215,6 +1755,66 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/x-date-pickers@npm:7.29.4":
+  version: 7.29.4
+  resolution: "@mui/x-date-pickers@npm:7.29.4"
+  dependencies:
+    "@babel/runtime": "npm:^7.25.7"
+    "@mui/utils": "npm:^5.16.6 || ^6.0.0 || ^7.0.0"
+    "@mui/x-internals": "npm:7.29.0"
+    "@types/react-transition-group": "npm:^4.4.11"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    react-transition-group: "npm:^4.4.5"
+  peerDependencies:
+    "@emotion/react": ^11.9.0
+    "@emotion/styled": ^11.8.1
+    "@mui/material": ^5.15.14 || ^6.0.0 || ^7.0.0
+    "@mui/system": ^5.15.14 || ^6.0.0 || ^7.0.0
+    date-fns: ^2.25.0 || ^3.2.0 || ^4.0.0
+    date-fns-jalali: ^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0
+    dayjs: ^1.10.7
+    luxon: ^3.0.2
+    moment: ^2.29.4
+    moment-hijri: ^2.1.2 || ^3.0.0
+    moment-jalaali: ^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    date-fns:
+      optional: true
+    date-fns-jalali:
+      optional: true
+    dayjs:
+      optional: true
+    luxon:
+      optional: true
+    moment:
+      optional: true
+    moment-hijri:
+      optional: true
+    moment-jalaali:
+      optional: true
+  checksum: 10c0/d56a0749da577979ad88e0f18dbb624a483458f5d8efe75d9d6b1b460edfd50579f7f6d6cde5cc0a7ec662cfa98fbe1865109cbf6cbc49d02606d0e1cc324ed7
+  languageName: node
+  linkType: hard
+
+"@mui/x-internals@npm:7.29.0":
+  version: 7.29.0
+  resolution: "@mui/x-internals@npm:7.29.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.25.7"
+    "@mui/utils": "npm:^5.16.6 || ^6.0.0 || ^7.0.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/adb4358ef0e29f6f57622b50ff479e9d225078761b4c82546343e2976ccb55eed687e122c37874c76a170f4ec2ea6e82f89bf8b9c0ef3b5cb35b32d026761fba
+  languageName: node
+  linkType: hard
+
 "@mui/x-license-pro@npm:5.17.12":
   version: 5.17.12
   resolution: "@mui/x-license-pro@npm:5.17.12"
@@ -1224,6 +1824,19 @@ __metadata:
   peerDependencies:
     react: ^17.0.2 || ^18.0.0
   checksum: 10c0/ad7f6a52e71e4c99a5f8d0bac5f78e278026d6a948eeb0382629392c05edf3665b90339afb8a0947566d3afcc73c24990f0fb86b9cddeb3ec7065dad794c8492
+  languageName: node
+  linkType: hard
+
+"@mui/x-license@npm:7.29.1, @mui/x-license@npm:^7.24.1":
+  version: 7.29.1
+  resolution: "@mui/x-license@npm:7.29.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.25.7"
+    "@mui/utils": "npm:^5.16.6 || ^6.0.0 || ^7.0.0"
+    "@mui/x-internals": "npm:7.29.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/c2bc01b0d6018d454084b867cdb89b766c5361a646f09a32f392d62ea5a20385c7b372930e791410d1b535ff7a1e644920f19d322cb930a5b7eca22eab4eccb1
   languageName: node
   linkType: hard
 
@@ -1246,6 +1859,33 @@ __metadata:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
   checksum: 10c0/53d883fed2b16c76dad1588cdfe0e36142705f9c9782a645a29de3739f14bcfe0e6515d32f77a8909279f9a97eec7cb8324e43361d89e85363440ebf365bc144
+  languageName: node
+  linkType: hard
+
+"@mui/x-tree-view@npm:^7.24.0":
+  version: 7.29.1
+  resolution: "@mui/x-tree-view@npm:7.29.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.25.7"
+    "@mui/utils": "npm:^5.16.6 || ^6.0.0 || ^7.0.0"
+    "@mui/x-internals": "npm:7.29.0"
+    "@types/react-transition-group": "npm:^4.4.11"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    react-transition-group: "npm:^4.4.5"
+  peerDependencies:
+    "@emotion/react": ^11.9.0
+    "@emotion/styled": ^11.8.1
+    "@mui/material": ^5.15.14 || ^6.0.0 || ^7.0.0
+    "@mui/system": ^5.15.14 || ^6.0.0 || ^7.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+  checksum: 10c0/302a07f97e09cda937d82c9ade61c2f2667808afb9eee7e89b1519111b90a6a436d8e8e392d5005ec9b17ae062ba8a54fbf10ff22c2b6080cd3e68959463db73
   languageName: node
   linkType: hard
 
@@ -1298,10 +1938,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@open-wc/dedupe-mixin@npm:^1.3.0":
+  version: 1.4.0
+  resolution: "@open-wc/dedupe-mixin@npm:1.4.0"
+  checksum: 10c0/22a1362c358b5f011e8f1b8923ad3f2287f493a7d016feeea82cae8df9357c7ebf06f7e7e2c70d9ec4bc214361335eead2ca27767d877c253544db2462fb73e5
+  languageName: node
+  linkType: hard
+
+"@parse5/tools@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@parse5/tools@npm:0.3.0"
+  dependencies:
+    parse5: "npm:^7.0.0"
+  checksum: 10c0/2bee032a2567e15cf8d403db386644f430c6ee3ea8300f7f386502ea6d0e74adbc0f60c6a825fd0f657027e2b0f20e52ad973ad875892b4dad0e50f1332c9179
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
   checksum: 10c0/5bd7576bb1b38a47a7fc7b51ac9f38748e772beebc56200450c4a817d712232b8f1d3ef70532c80840243c657d491cf6a6be1e3a214cff907645819fdc34aadd
+  languageName: node
+  linkType: hard
+
+"@polymer/polymer@npm:^3.0.0":
+  version: 3.5.2
+  resolution: "@polymer/polymer@npm:3.5.2"
+  dependencies:
+    "@webcomponents/shadycss": "npm:^1.9.1"
+  checksum: 10c0/03862c94dea52ac61be8875b70a3565842c4491016d6edc4a7c43050922c2170b9a4f1613587e94453030168129ef320234dba5a7a9e80ce4ba2babe82b01e74
   languageName: node
   linkType: hard
 
@@ -1442,7 +2107,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/format-util@npm:^1.0.2":
+"@types/format-util@npm:^1.0.2, @types/format-util@npm:^1.0.4":
   version: 1.0.4
   resolution: "@types/format-util@npm:1.0.4"
   checksum: 10c0/173d1f67155c82311aaa5e90467351a18db17253c7d10174dc5a54d942415f1aa1f693f33ac4b15855e6f90363becb925651337692b3817271037f3d86b6e9f5
@@ -1535,6 +2200,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^16.0.0":
+  version: 16.18.126
+  resolution: "@types/node@npm:16.18.126"
+  checksum: 10c0/5c137eb141d33de32b16ff26047ff6d449432b58d0d25f7cced2040c97727d81fe1099a7581eb336d14a6840f5b09e363bdd43d7a6995e8e81eb47aa51e413fc
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^16.18.39":
   version: 16.18.100
   resolution: "@types/node@npm:16.18.100"
@@ -1577,6 +2249,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prop-types@npm:^15.7.14":
+  version: 15.7.15
+  resolution: "@types/prop-types@npm:15.7.15"
+  checksum: 10c0/b59aad1ad19bf1733cf524fd4e618196c6c7690f48ee70a327eb450a42aab8e8a063fbe59ca0a5701aebe2d92d582292c0fb845ea57474f6a15f6994b0e260b2
+  languageName: node
+  linkType: hard
+
 "@types/qs@npm:*":
   version: 6.9.15
   resolution: "@types/qs@npm:6.9.15"
@@ -1604,6 +2283,15 @@ __metadata:
   dependencies:
     "@types/react": "npm:*"
   checksum: 10c0/74dba11a1b8156f3a763f3fca1fb4ec1dcd349153279b8bf79210024a69f994bf2cf0728198c047f8130c5318420ea56281b0a4ef84c8ae943cd9a0cac705220
+  languageName: node
+  linkType: hard
+
+"@types/react-transition-group@npm:^4.4.11, @types/react-transition-group@npm:^4.4.12":
+  version: 4.4.12
+  resolution: "@types/react-transition-group@npm:4.4.12"
+  peerDependencies:
+    "@types/react": "*"
+  checksum: 10c0/0441b8b47c69312c89ec0760ba477ba1a0808a10ceef8dc1c64b1013ed78517332c30f18681b0ec0b53542731f1ed015169fed1d127cc91222638ed955478ec7
   languageName: node
   linkType: hard
 
@@ -1702,10 +2390,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/sortablejs@npm:^1.15.8":
+  version: 1.15.8
+  resolution: "@types/sortablejs@npm:1.15.8"
+  checksum: 10c0/cac9c8279ead93b5fc6b0dde6bf4b1c4fe067d40d7b2b3415880df823f2efe5779616009488f940a003687ace70cb3d52bda168dfad2b5f4242403cd8f4ed500
+  languageName: node
+  linkType: hard
+
 "@types/three@npm:^0.134.0":
   version: 0.134.0
   resolution: "@types/three@npm:0.134.0"
   checksum: 10c0/7ca4c437584a3103370c5c4200e4f0a84f4e1a471f862d925315ab1abe2b501e318062fd87482211a9a79be0e2510e88a8153100bbd57516263a21395f4b507c
+  languageName: node
+  linkType: hard
+
+"@types/trusted-types@npm:^2.0.2":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 10c0/4c4855f10de7c6c135e0d32ce462419d8abbbc33713b31d294596c0cc34ae1fa6112a2f9da729c8f7a20707782b0d69da3b1f8df6645b0366d08825ca1522e0c
   languageName: node
   linkType: hard
 
@@ -1873,6 +2575,184 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vaadin/a11y-base@npm:~24.6.11":
+  version: 24.6.11
+  resolution: "@vaadin/a11y-base@npm:24.6.11"
+  dependencies:
+    "@open-wc/dedupe-mixin": "npm:^1.3.0"
+    "@polymer/polymer": "npm:^3.0.0"
+    "@vaadin/component-base": "npm:~24.6.11"
+    lit: "npm:^3.0.0"
+  checksum: 10c0/0bd8ab1b9729a69e92dd4d631293e54e876e3739b9e658c3f332ac5e2ddf075744f40fd35a9c0c278d0c0181697da51f4df22541d3c65c59f74d2c863806abbe
+  languageName: node
+  linkType: hard
+
+"@vaadin/checkbox@npm:~24.6.11":
+  version: 24.6.11
+  resolution: "@vaadin/checkbox@npm:24.6.11"
+  dependencies:
+    "@open-wc/dedupe-mixin": "npm:^1.3.0"
+    "@polymer/polymer": "npm:^3.0.0"
+    "@vaadin/a11y-base": "npm:~24.6.11"
+    "@vaadin/component-base": "npm:~24.6.11"
+    "@vaadin/field-base": "npm:~24.6.11"
+    "@vaadin/vaadin-lumo-styles": "npm:~24.6.11"
+    "@vaadin/vaadin-material-styles": "npm:~24.6.11"
+    "@vaadin/vaadin-themable-mixin": "npm:~24.6.11"
+    lit: "npm:^3.0.0"
+  checksum: 10c0/068d3045fd02a0f6d3ab34b2b78018aec5bde7cc9a15f59d275eb03c10894c1777720482c4a9fb30b561cfea60e2714183e3576c4c82a22e6386e391c1065142
+  languageName: node
+  linkType: hard
+
+"@vaadin/component-base@npm:~24.6.11":
+  version: 24.6.11
+  resolution: "@vaadin/component-base@npm:24.6.11"
+  dependencies:
+    "@open-wc/dedupe-mixin": "npm:^1.3.0"
+    "@polymer/polymer": "npm:^3.0.0"
+    "@vaadin/vaadin-development-mode-detector": "npm:^2.0.0"
+    "@vaadin/vaadin-usage-statistics": "npm:^2.1.0"
+    lit: "npm:^3.0.0"
+  checksum: 10c0/6f1e141d94b6030c0e7891ce2be5a052664cbf305caa0c5b60b1da1ecc0fce7334a8da5cc679f0a023a64ec7fd5be367726cda7b64c34e45cdc9c0ae1dfe6a6e
+  languageName: node
+  linkType: hard
+
+"@vaadin/field-base@npm:~24.6.11":
+  version: 24.6.11
+  resolution: "@vaadin/field-base@npm:24.6.11"
+  dependencies:
+    "@open-wc/dedupe-mixin": "npm:^1.3.0"
+    "@polymer/polymer": "npm:^3.0.0"
+    "@vaadin/a11y-base": "npm:~24.6.11"
+    "@vaadin/component-base": "npm:~24.6.11"
+    lit: "npm:^3.0.0"
+  checksum: 10c0/1dcff1534ee86687862a166b4ae8b91c4497addfe8ad32f20d1e0b2be52cc4b494186965252ba022206690dc1aad2709e00db8201679cd3de693341f2c23376e
+  languageName: node
+  linkType: hard
+
+"@vaadin/grid@npm:~24.6.4":
+  version: 24.6.11
+  resolution: "@vaadin/grid@npm:24.6.11"
+  dependencies:
+    "@open-wc/dedupe-mixin": "npm:^1.3.0"
+    "@polymer/polymer": "npm:^3.0.0"
+    "@vaadin/a11y-base": "npm:~24.6.11"
+    "@vaadin/checkbox": "npm:~24.6.11"
+    "@vaadin/component-base": "npm:~24.6.11"
+    "@vaadin/lit-renderer": "npm:~24.6.11"
+    "@vaadin/text-field": "npm:~24.6.11"
+    "@vaadin/vaadin-lumo-styles": "npm:~24.6.11"
+    "@vaadin/vaadin-material-styles": "npm:~24.6.11"
+    "@vaadin/vaadin-themable-mixin": "npm:~24.6.11"
+    lit: "npm:^3.0.0"
+  checksum: 10c0/da2445ee8c26afee796ab480b25c5bd49cd776356ab0cc9ea53a1275e543da3bc6006167183e3f7bf19ee6aa44883040c29d2973c59d3a08cb41dd6b9256a6fb
+  languageName: node
+  linkType: hard
+
+"@vaadin/icon@npm:~24.6.11":
+  version: 24.6.11
+  resolution: "@vaadin/icon@npm:24.6.11"
+  dependencies:
+    "@open-wc/dedupe-mixin": "npm:^1.3.0"
+    "@polymer/polymer": "npm:^3.0.0"
+    "@vaadin/component-base": "npm:~24.6.11"
+    "@vaadin/vaadin-lumo-styles": "npm:~24.6.11"
+    "@vaadin/vaadin-themable-mixin": "npm:~24.6.11"
+    lit: "npm:^3.0.0"
+  checksum: 10c0/047d29b3ecf694ffa73e3db7bf92140eec8c52d44b6c56e85d2bedcefa4b39524cc518f762b53698e656905eabde1f8f30ec6b99e744efd276b119034292905f
+  languageName: node
+  linkType: hard
+
+"@vaadin/input-container@npm:~24.6.11":
+  version: 24.6.11
+  resolution: "@vaadin/input-container@npm:24.6.11"
+  dependencies:
+    "@polymer/polymer": "npm:^3.0.0"
+    "@vaadin/component-base": "npm:~24.6.11"
+    "@vaadin/vaadin-lumo-styles": "npm:~24.6.11"
+    "@vaadin/vaadin-material-styles": "npm:~24.6.11"
+    "@vaadin/vaadin-themable-mixin": "npm:~24.6.11"
+    lit: "npm:^3.0.0"
+  checksum: 10c0/3ffbcfb787b0b5fbdfd6604d3fd479dd7dc8789bfc0eee7cf4ddfcd34fccf005179234f88eacc57d2bc985e5bcd06e201b8fa8b1dcf2596a4eb3ab07bbfc04fb
+  languageName: node
+  linkType: hard
+
+"@vaadin/lit-renderer@npm:~24.6.11":
+  version: 24.6.11
+  resolution: "@vaadin/lit-renderer@npm:24.6.11"
+  dependencies:
+    lit: "npm:^3.0.0"
+  checksum: 10c0/8edc0483799c01ddf2861922f140e0a0e35ea0b97b9a2e8af75fdfdafca518b4c530d080586ed3310b9b828d98e08902c3a7d91239cc67a4184c73ea91d7247b
+  languageName: node
+  linkType: hard
+
+"@vaadin/text-field@npm:~24.6.11":
+  version: 24.6.11
+  resolution: "@vaadin/text-field@npm:24.6.11"
+  dependencies:
+    "@open-wc/dedupe-mixin": "npm:^1.3.0"
+    "@polymer/polymer": "npm:^3.0.0"
+    "@vaadin/a11y-base": "npm:~24.6.11"
+    "@vaadin/component-base": "npm:~24.6.11"
+    "@vaadin/field-base": "npm:~24.6.11"
+    "@vaadin/input-container": "npm:~24.6.11"
+    "@vaadin/vaadin-lumo-styles": "npm:~24.6.11"
+    "@vaadin/vaadin-material-styles": "npm:~24.6.11"
+    "@vaadin/vaadin-themable-mixin": "npm:~24.6.11"
+    lit: "npm:^3.0.0"
+  checksum: 10c0/9ada446cdf126a927771a85ca14ea19de1b0385c049444ee64a5d9275836a4bd93f2a8969677833182bd6a2664c3ea2f399ed87e26fd327e3e29aac83bb58791
+  languageName: node
+  linkType: hard
+
+"@vaadin/vaadin-development-mode-detector@npm:^2.0.0":
+  version: 2.0.7
+  resolution: "@vaadin/vaadin-development-mode-detector@npm:2.0.7"
+  checksum: 10c0/b62f65a60a734932939ee523d854fefb4a568c10787ca82b5d9377b1536249886f5b07eebf56e6e31e1e3da0d6bc32b03b2eba791be12b2420747cf178231032
+  languageName: node
+  linkType: hard
+
+"@vaadin/vaadin-lumo-styles@npm:~24.6.11":
+  version: 24.6.11
+  resolution: "@vaadin/vaadin-lumo-styles@npm:24.6.11"
+  dependencies:
+    "@polymer/polymer": "npm:^3.0.0"
+    "@vaadin/component-base": "npm:~24.6.11"
+    "@vaadin/icon": "npm:~24.6.11"
+    "@vaadin/vaadin-themable-mixin": "npm:~24.6.11"
+  checksum: 10c0/64c67616f59e48bf89b0ac7fd9f0624f52a6b2467219243ff364888677429276149cd8fb43808271116cd7533f0b91fa5a65c928edbc83cf839614218875e470
+  languageName: node
+  linkType: hard
+
+"@vaadin/vaadin-material-styles@npm:~24.6.11":
+  version: 24.6.11
+  resolution: "@vaadin/vaadin-material-styles@npm:24.6.11"
+  dependencies:
+    "@polymer/polymer": "npm:^3.0.0"
+    "@vaadin/component-base": "npm:~24.6.11"
+    "@vaadin/vaadin-themable-mixin": "npm:~24.6.11"
+  checksum: 10c0/b3449bfff69854b0e909ce654431cceead4e5e67a95cc2fd829cba7d154d10b4667fc8009e5b238b7c2c583e8e871c8050aa245b0043537ebd4e486ef2df86ea
+  languageName: node
+  linkType: hard
+
+"@vaadin/vaadin-themable-mixin@npm:~24.6.11":
+  version: 24.6.11
+  resolution: "@vaadin/vaadin-themable-mixin@npm:24.6.11"
+  dependencies:
+    "@open-wc/dedupe-mixin": "npm:^1.3.0"
+    lit: "npm:^3.0.0"
+  checksum: 10c0/b7b4f12dd16b33d2ab7c53b32ca985ebf894165cc4f4e043f81d7916b5f7be03910bc6e7012c7d80ead5a7668ea3ff2bebdbb3f2a137d2a195393cd51cf7719f
+  languageName: node
+  linkType: hard
+
+"@vaadin/vaadin-usage-statistics@npm:^2.1.0":
+  version: 2.1.3
+  resolution: "@vaadin/vaadin-usage-statistics@npm:2.1.3"
+  dependencies:
+    "@vaadin/vaadin-development-mode-detector": "npm:^2.0.0"
+  checksum: 10c0/b1f1182cd7d4c03ba99371f70b446c69fda7fd259550de8ed8576df429030ac9c5ab78707ae5dc23cb3d5cab06ae2e74acfaa4a28010d1d50d18c5577e4712fb
+  languageName: node
+  linkType: hard
+
 "@vertigis/arcgis-extensions@npm:44.1.3":
   version: 44.1.3
   resolution: "@vertigis/arcgis-extensions@npm:44.1.3"
@@ -1893,23 +2773,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vertigis/arcgis-extensions@npm:^45.2.0":
-  version: 45.6.0
-  resolution: "@vertigis/arcgis-extensions@npm:45.6.0"
+"@vertigis/arcgis-extensions@npm:49.5.0":
+  version: 49.5.0
+  resolution: "@vertigis/arcgis-extensions@npm:49.5.0"
   dependencies:
-    alasql: "npm:~4.2.3"
+    alasql: "npm:~4.5.2"
     elasticlunr: "npm:~0.9.5"
     esri-proj-codes: "npm:~1.0.3"
-    jszip: "npm:~3.10.0"
-    luxon: "npm:~3.4.3"
-    safe-stable-stringify: "npm:^2.4.2"
-    shpjs: "npm:~4.0.2 "
-    ts-essentials: "npm:9.4.1"
-    xlsx: "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
+    jszip: "npm:~3.10.1"
+    luxon: "npm:~3.5.0"
+    safe-stable-stringify: "npm:^2.5.0"
+    shpjs: "npm:~4.0.2"
+    ts-essentials: "npm:10.0.3"
+    xlsx: "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
   peerDependencies:
-    "@arcgis/core": ~4.28.6
+    "@arcgis/core": 4.32.10
     tslib: ^2.6.2
-  checksum: 10c0/9c26516321eb1793b9dc32fd80d5b107d519c3f106860816954b503bb5b2a04b2c14f853e6bc4e4f3b5075782a03a45d8f44250b56066db7fd233cb389f56717
+  checksum: 10c0/b7063a4e79e4d52e11fde9db5e4a58bb7d5b1f74f2dd3d188244b112ff6620bb5b2eb7853f80ffa0cb6e1ec6dc7e334010f2e5666806d99848e7bcecb5403b17
   languageName: node
   linkType: hard
 
@@ -1941,6 +2821,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vertigis/react-ui@npm:19.5.1":
+  version: 19.5.1
+  resolution: "@vertigis/react-ui@npm:19.5.1"
+  dependencies:
+    "@mui/icons-material": "npm:^6.4.0"
+    "@mui/material": "npm:^6.4.0"
+    "@mui/x-data-grid-pro": "npm:^7.24.0"
+    "@mui/x-date-pickers-pro": "npm:^7.24.0"
+    "@mui/x-license": "npm:^7.24.1"
+    "@mui/x-tree-view": "npm:^7.24.0"
+    autosuggest-highlight: "npm:^3.3.4"
+    clsx: "npm:^2.1.0"
+    color: "npm:^4.2.3"
+    lodash.escape: "npm:^4.0.1"
+    marked: "npm:^12.0.1"
+    react-color: "npm:^2.19.3"
+    tslib: "npm:^2.6.2"
+    xss: "npm:^1.0.15"
+  peerDependencies:
+    "@emotion/react": "*"
+    "@emotion/styled": "*"
+    "@esri/arcgis-html-sanitizer": ^4.0.3
+    "@mui/system": "*"
+    react: ">= 18 < 20"
+    react-dom: ">= 18 < 20"
+  checksum: 10c0/a003855bb1621d628e986719f88c033b2ffceebad2d52dfdd543678772dcfa5019a0f16de3813db656df106b9f56738adac5d95f512e6adf4cc608038f5a0e5c
+  languageName: node
+  linkType: hard
+
 "@vertigis/viewer-spec@npm:56.32.1":
   version: 56.32.1
   resolution: "@vertigis/viewer-spec@npm:56.32.1"
@@ -1951,13 +2860,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vertigis/viewer-spec@npm:^57.2.0":
-  version: 57.2.0
-  resolution: "@vertigis/viewer-spec@npm:57.2.0"
+"@vertigis/viewer-spec@npm:58.24.1":
+  version: 58.24.1
+  resolution: "@vertigis/viewer-spec@npm:58.24.1"
   peerDependencies:
     "@arcgis/core": "*"
-    "@vertigis/arcgis-extensions": ">= 45.0.0-0 < 46.0.0-0"
-  checksum: 10c0/23db5e3ed83322cac1ed8cc009e79af9d90edcd48502715338fd197297c9de4e46ade2b8f091b4e91b664c45d5c357151780b150d431958bfc780796ce98c4c9
+    "@vertigis/arcgis-extensions": ">= 49.0.0-0 < 50.0.0-0"
+    highcharts: "*"
+  checksum: 10c0/2103d7bb809ffd0e40ef51172f9694f9a42265147e07aa5c364a62f3d70bfb45e9784c38a6c2fcfd3fa7fe9f71c63f634a5a77fbe6c9273ca360aea607657120
   languageName: node
   linkType: hard
 
@@ -2008,6 +2918,23 @@ __metadata:
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"
   checksum: 10c0/ba2c2d15a7dab32c1d74a3e1ace3f963ad1e4885c6c68186fe32a77f2359023ec801ce11cf085f6aa98c3394581ef8ab2d9b08d6be586b49a1c860732253e26b
+  languageName: node
+  linkType: hard
+
+"@vertigis/web@npm:^5.36.0":
+  version: 5.36.0
+  resolution: "@vertigis/web@npm:5.36.0"
+  dependencies:
+    "@arcgis/core": "npm:4.32.10"
+    "@types/react": "npm:18.2.46"
+    "@types/react-dom": "npm:18.2.18"
+    "@types/react-window": "npm:1.8.8"
+    "@vertigis/arcgis-extensions": "npm:49.5.0"
+    "@vertigis/react-ui": "npm:19.5.1"
+    "@vertigis/viewer-spec": "npm:58.24.1"
+    react: "npm:18.2.0"
+    react-dom: "npm:18.2.0"
+  checksum: 10c0/c5504cdffbcc7476f0aabdc774933c4d9190b004c18f349a97ecd64e6812ddc1130bd17f7658685dd70af813293596fc02e1bca9587089726aa9c6ffc90d1dd4
   languageName: node
   linkType: hard
 
@@ -2162,6 +3089,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webcomponents/shadycss@npm:^1.9.1":
+  version: 1.11.2
+  resolution: "@webcomponents/shadycss@npm:1.11.2"
+  checksum: 10c0/0f6f6545c0805e307747014e693a30e8d4128dea9ceca66884075de49bf7dee52461255b9136962fd19d6da075ad732f622c4ada9ee4d27e34c331ecb302e27b
+  languageName: node
+  linkType: hard
+
 "@xtuc/ieee754@npm:^1.2.0":
   version: 1.2.0
   resolution: "@xtuc/ieee754@npm:1.2.0"
@@ -2180,6 +3114,13 @@ __metadata:
   version: 2.7.45
   resolution: "@zip.js/zip.js@npm:2.7.45"
   checksum: 10c0/bc39b849d6e92d33b7d09ef1ae623e2011984b3c93004b559bdea2d024842406310b5112f825261664c331b04e4db49d08de6bba509cb9265adf3ae9c85569de
+  languageName: node
+  linkType: hard
+
+"@zip.js/zip.js@npm:~2.7.57":
+  version: 2.7.62
+  resolution: "@zip.js/zip.js@npm:2.7.62"
+  checksum: 10c0/269da31f7514ccbdd8766f0b0c440edb7df53add731862c97f3b27b594182466ce62a03fa4be5ed736a5ac0cd1c5ead09d35c97e27887c8c6f6bfd477102ea8f
   languageName: node
   linkType: hard
 
@@ -2313,6 +3254,18 @@ __metadata:
   bin:
     alasql: bin/alasql-cli.js
   checksum: 10c0/5a549da40a141ed7432a6f0d3bc4115ee9827d8d42e1214a62c396e8cd477ca0078706edc1ae6d0399cbb795a60033877deebcf7991af391c651b39259f93add
+  languageName: node
+  linkType: hard
+
+"alasql@npm:~4.5.2":
+  version: 4.5.2
+  resolution: "alasql@npm:4.5.2"
+  dependencies:
+    cross-fetch: "npm:4"
+    yargs: "npm:16"
+  bin:
+    alasql: bin/alasql-cli.js
+  checksum: 10c0/db143e36964ab4a65a9413e44ebb9840537534fe3fc4f22629a8c166c35c4d369ddfa7551d6a431eacaf9385c635b93d2f59239b39be2e17bacfd47a79ca425d
   languageName: node
   linkType: hard
 
@@ -3121,6 +4074,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-convert@npm:^3.0.1":
+  version: 3.1.0
+  resolution: "color-convert@npm:3.1.0"
+  dependencies:
+    color-name: "npm:^2.0.0"
+  checksum: 10c0/3e6c92a7122dc8429036f134fdc821064fcf34c4ed67855d6ec29c207eb96e761dbb37bb2a64572a703fc3a7a8fa4e970e0a194619b2acd46b55bcd2ace06293
+  languageName: node
+  linkType: hard
+
 "color-name@npm:1.1.3":
   version: 1.1.3
   resolution: "color-name@npm:1.1.3"
@@ -3135,6 +4097,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-name@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "color-name@npm:2.0.0"
+  checksum: 10c0/fc0304606e5c5941f4649a9975c03a2ecd52a22aba3dadb3309b3e4ee61d78c3e13ff245e80b9a930955d38c5f32a9004196a7456c4542822aa1fcfea8e928ed
+  languageName: node
+  linkType: hard
+
 "color-string@npm:^1.9.0":
   version: 1.9.1
   resolution: "color-string@npm:1.9.1"
@@ -3145,6 +4114,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-string@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "color-string@npm:2.0.1"
+  dependencies:
+    color-name: "npm:^2.0.0"
+  checksum: 10c0/8547edb171cfcc9b56d54664560fba98afd065deedd6812e9545be6448c9c38f89dff51e38d18249b3670fa11647824cbcb77bfbb0c8bff8e37c53c9c0baecc1
+  languageName: node
+  linkType: hard
+
 "color@npm:4.2.3, color@npm:^4.2.3":
   version: 4.2.3
   resolution: "color@npm:4.2.3"
@@ -3152,6 +4130,16 @@ __metadata:
     color-convert: "npm:^2.0.1"
     color-string: "npm:^1.9.0"
   checksum: 10c0/7fbe7cfb811054c808349de19fb380252e5e34e61d7d168ec3353e9e9aacb1802674bddc657682e4e9730c2786592a4de6f8283e7e0d3870b829bb0b7b2f6118
+  languageName: node
+  linkType: hard
+
+"color@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "color@npm:5.0.0"
+  dependencies:
+    color-convert: "npm:^3.0.1"
+    color-string: "npm:^2.0.0"
+  checksum: 10c0/fa5f2e84add2e1622abe016b917cca739535fc9845305db32043a5bde4b8164033f179fd1807ac3fe52c9ee7888f82d80e5ff90d1e2652454a2341ab3d23d086
   languageName: node
   linkType: hard
 
@@ -3210,6 +4198,15 @@ __metadata:
   version: 0.0.4
   resolution: "composed-offset-position@npm:0.0.4"
   checksum: 10c0/530cd316c9f2ba7ac12a83c7726bb5c3fc4fdf905950acc2492b9e7ca19ec92424306e098ebf353ad1a60dc6dc90f38dbe647d4f5710257230f3ab9e44b20a35
+  languageName: node
+  linkType: hard
+
+"composed-offset-position@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "composed-offset-position@npm:0.0.6"
+  peerDependencies:
+    "@floating-ui/utils": ^0.2.5
+  checksum: 10c0/aa8f91a8744806855b8019537c40a6f6fc61a8054d9f46b0b0c1feafadfb07d62fb660bf68db5e7ac9a339780046526e6c64402b6cdd25f3d6a4e06880c2c9b4
   languageName: node
   linkType: hard
 
@@ -3609,6 +4606,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dayjs@npm:^1.11.13":
+  version: 1.11.13
+  resolution: "dayjs@npm:1.11.13"
+  checksum: 10c0/a3caf6ac8363c7dade9d1ee797848ddcf25c1ace68d9fe8678ecf8ba0675825430de5d793672ec87b24a69bf04a1544b176547b2539982275d5542a7955f35b7
+  languageName: node
+  linkType: hard
+
 "debug@npm:2.6.9":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
@@ -3964,6 +4968,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"enhanced-resolve@npm:^5.10.0":
+  version: 5.18.1
+  resolution: "enhanced-resolve@npm:5.18.1"
+  dependencies:
+    graceful-fs: "npm:^4.2.4"
+    tapable: "npm:^2.2.0"
+  checksum: 10c0/4cffd9b125225184e2abed9fdf0ed3dbd2224c873b165d0838fd066cde32e0918626cba2f1f4bf6860762f13a7e2364fd89a82b99566be2873d813573ac71846
+  languageName: node
+  linkType: hard
+
 "enquirer@npm:^2.3.6":
   version: 2.4.1
   resolution: "enquirer@npm:2.4.1"
@@ -3978,6 +4992,13 @@ __metadata:
   version: 2.2.0
   resolution: "entities@npm:2.2.0"
   checksum: 10c0/7fba6af1f116300d2ba1c5673fc218af1961b20908638391b4e1e6d5850314ee2ac3ec22d741b3a8060479911c99305164aed19b6254bde75e7e6b1b2c3f3aa3
+  languageName: node
+  linkType: hard
+
+"entities@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "entities@npm:6.0.1"
+  checksum: 10c0/ed836ddac5acb34341094eb495185d527bd70e8632b6c0d59548cbfa23defdbae70b96f9a405c82904efa421230b5b3fd2283752447d737beffd3f3e6ee74414
   languageName: node
   linkType: hard
 
@@ -4795,6 +5816,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"focus-trap@npm:^7.6.2":
+  version: 7.6.5
+  resolution: "focus-trap@npm:7.6.5"
+  dependencies:
+    tabbable: "npm:^6.2.0"
+  checksum: 10c0/36cac0d9b05fe5824733675bb49792842dae4704286ef7e17c736ee0c9c14701e874e6821449e78b70c17e42ba1b2c98ef10434bfe644b9d7654d8ef7f1c8faf
+  languageName: node
+  linkType: hard
+
 "follow-redirects@npm:^1.0.0":
   version: 1.15.6
   resolution: "follow-redirects@npm:1.15.6"
@@ -5609,6 +6639,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"interactjs@npm:^1.10.27":
+  version: 1.10.27
+  resolution: "interactjs@npm:1.10.27"
+  dependencies:
+    "@interactjs/types": "npm:1.10.27"
+  checksum: 10c0/35532c636fc7cf8273999d314c9738994bfc4a1a384fd64658420055e93456aa6333a865e04b1765d39ee4e29f898854c3f3451a7a88a09141e32115cc6112e2
+  languageName: node
+  linkType: hard
+
 "internal-slot@npm:^1.0.7":
   version: 1.0.7
   resolution: "internal-slot@npm:1.0.7"
@@ -6242,7 +7281,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jszip@npm:^3.5.0, jszip@npm:~3.10.0":
+"jszip@npm:^3.5.0, jszip@npm:~3.10.0, jszip@npm:~3.10.1":
   version: 3.10.1
   resolution: "jszip@npm:3.10.1"
   dependencies:
@@ -6315,10 +7354,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "library-time-slider@workspace:libraries/timeslider"
   dependencies:
-    "@arcgis/core": "npm:~4.28.6"
-    "@vertigis/arcgis-extensions": "npm:^45.2.0"
-    "@vertigis/viewer-spec": "npm:^57.2.0"
-    "@vertigis/web": "npm:^5.29.0"
+    "@vertigis/web": "npm:^5.36.0"
     "@vertigis/web-sdk": "npm:^1.10.0"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.3.3"
@@ -6422,6 +7458,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lit-element@npm:^4.0.4, lit-element@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "lit-element@npm:4.2.0"
+  dependencies:
+    "@lit-labs/ssr-dom-shim": "npm:^1.2.0"
+    "@lit/reactive-element": "npm:^2.1.0"
+    lit-html: "npm:^3.3.0"
+  checksum: 10c0/20577f2092ac1e1bd82fba2bbc9ce0122b35dc2495906d3fbcb437c3727b9c8ed1c0691b8b859f65a51e910db1341d95233c117e1e1c88c450b30e2d3b62fdb8
+  languageName: node
+  linkType: hard
+
+"lit-html@npm:^3.1.2, lit-html@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "lit-html@npm:3.3.0"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.2"
+  checksum: 10c0/c1065048d89d93df6a46cdeed9abd637ae9bcc0847ee108dccbb2e1627a4074074e1d3ac9360e08a736d76f8c76b2c88166dbe465406da123b9137e29c2e0034
+  languageName: node
+  linkType: hard
+
+"lit@npm:^3.0.0, lit@npm:^3.1.2, lit@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "lit@npm:3.3.0"
+  dependencies:
+    "@lit/reactive-element": "npm:^2.1.0"
+    lit-element: "npm:^4.2.0"
+    lit-html: "npm:^3.3.0"
+  checksum: 10c0/27e6d109c04c8995f47c82a546407c5ed8d399705f9511d1f3ee562eb1ab4bc00fae5ec897da55fb50f202b2a659466e23cccd809d039e7d4f935fcecb2bc6a7
+  languageName: node
+  linkType: hard
+
 "loader-runner@npm:^4.2.0":
   version: 4.3.0
   resolution: "loader-runner@npm:4.3.0"
@@ -6449,7 +7516,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:4.17.21, lodash-es@npm:^4.17.15":
+"lodash-es@npm:4.17.21, lodash-es@npm:^4.17.15, lodash-es@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash-es@npm:4.17.21"
   checksum: 10c0/fb407355f7e6cd523a9383e76e6b455321f0f153a6c9625e21a8827d10c54c2a2341bd2ae8d034358b60e07325e1330c14c224ff582d04612a46a4f0479ff2f2
@@ -6567,6 +7634,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"luxon@npm:~3.5.0":
+  version: 3.5.0
+  resolution: "luxon@npm:3.5.0"
+  checksum: 10c0/335789bba95077db831ef99894edadeb23023b3eb2137a1b56acd0d290082b691cf793143d69e30bc069ec95f0b49f36419f48e951c68014f19ffe12045e3494
+  languageName: node
+  linkType: hard
+
 "make-fetch-happen@npm:^13.0.0":
   version: 13.0.1
   resolution: "make-fetch-happen@npm:13.0.1"
@@ -6619,6 +7693,24 @@ __metadata:
   bin:
     marked: bin/marked.js
   checksum: 10c0/4713cceabdcd0b4de9a156d601a55ae7e9091cd89ba75d8283042ddbbedb7cd765e02445a80be01131aa24a79003346fc650d66bf4423f7aa186dcc46b403849
+  languageName: node
+  linkType: hard
+
+"marked@npm:^12.0.1":
+  version: 12.0.2
+  resolution: "marked@npm:12.0.2"
+  bin:
+    marked: bin/marked.js
+  checksum: 10c0/45ae2e1e3f06b30a5b5f64efc6cde9830c81d1d024fd7668772a3217f1bc0f326e66a6b8970482d9783edf1f581fecac7023a7fa160f2c14dbcc16e064b4eafb
+  languageName: node
+  linkType: hard
+
+"marked@npm:~15.0.6":
+  version: 15.0.12
+  resolution: "marked@npm:15.0.12"
+  bin:
+    marked: bin/marked.js
+  checksum: 10c0/e09da211544b787ecfb25fed07af206060bf7cd6d9de6cb123f15c496a57f83b7aabea93340aaa94dae9c94e097ae129377cad6310abc16009590972e85f4212
   languageName: node
   linkType: hard
 
@@ -6994,7 +8086,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:~3.3.2":
+"node-fetch@npm:^3.2.8, node-fetch@npm:~3.3.2":
   version: 3.3.2
   resolution: "node-fetch@npm:3.3.2"
   dependencies:
@@ -7355,6 +8447,15 @@ __metadata:
     json-parse-even-better-errors: "npm:^2.3.0"
     lines-and-columns: "npm:^1.1.6"
   checksum: 10c0/77947f2253005be7a12d858aedbafa09c9ae39eb4863adf330f7b416ca4f4a08132e453e08de2db46459256fb66afaac5ee758b44fe6541b7cdaf9d252e59585
+  languageName: node
+  linkType: hard
+
+"parse5@npm:^7.0.0, parse5@npm:^7.1.1":
+  version: 7.3.0
+  resolution: "parse5@npm:7.3.0"
+  dependencies:
+    entities: "npm:^6.0.0"
+  checksum: 10c0/7fd2e4e247e85241d6f2a464d0085eed599a26d7b0a5233790c49f53473232eb85350e8133344d9b3fd58b89339e7ad7270fe1f89d28abe50674ec97b87f80b5
   languageName: node
   linkType: hard
 
@@ -8257,6 +9358,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is@npm:^19.0.0, react-is@npm:^19.1.0":
+  version: 19.1.0
+  resolution: "react-is@npm:19.1.0"
+  checksum: 10c0/b6c6cadd172d5d39f66d493700d137a5545c294a62ce0f8ec793d59794c97d2bed6bad227626f16bd0e90004ed7fdc8ed662a004e6edcf5d2b7ecb6e3040ea6b
+  languageName: node
+  linkType: hard
+
 "react-transition-group@npm:^4.4.5":
   version: 4.4.5
   resolution: "react-transition-group@npm:4.4.5"
@@ -8429,6 +9537,13 @@ __metadata:
   version: 4.1.8
   resolution: "reselect@npm:4.1.8"
   checksum: 10c0/06a305a504affcbb67dd0561ddc8306b35796199c7e15b38934c80606938a021eadcf68cfd58e7bb5e17786601c37602a3362a4665c7bf0a96c1041ceee9d0b7
+  languageName: node
+  linkType: hard
+
+"reselect@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "reselect@npm:5.1.1"
+  checksum: 10c0/219c30da122980f61853db3aebd173524a2accd4b3baec770e3d51941426c87648a125ca08d8c57daa6b8b086f2fdd2703cb035dd6231db98cdbe1176a71f489
   languageName: node
   linkType: hard
 
@@ -8683,6 +9798,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-stable-stringify@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "safe-stable-stringify@npm:2.5.0"
+  checksum: 10c0/baea14971858cadd65df23894a40588ed791769db21bafb7fd7608397dbdce9c5aac60748abae9995e0fc37e15f2061980501e012cd48859740796bea2987f49
+  languageName: node
+  linkType: hard
+
 "safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0, safer-buffer@npm:^2.0.2, safer-buffer@npm:^2.1.0, safer-buffer@npm:~2.1.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
@@ -8915,7 +10037,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shpjs@npm:~4.0.2 ":
+"shpjs@npm:~4.0.2, shpjs@npm:~4.0.2 ":
   version: 4.0.4
   resolution: "shpjs@npm:4.0.4"
   dependencies:
@@ -9066,6 +10188,13 @@ __metadata:
   version: 1.15.0
   resolution: "sortablejs@npm:1.15.0"
   checksum: 10c0/de2e99309d6b8f5a521050c391cd3cbeeb5ac66cf91879b4212469cdcee13f6304bfacbfa183d43276deb618f40af6cb6d8a8c90ca3ba82ac28d8d5f5ef81bef
+  languageName: node
+  linkType: hard
+
+"sortablejs@npm:^1.15.6":
+  version: 1.15.6
+  resolution: "sortablejs@npm:1.15.6"
+  checksum: 10c0/a75dcf53e5613b4106d46434e40114830f9c6449b3b439bc1925c1fbf0a0c1f044727a8f3d4ae1759fa7beaa33e7eb0c4a413e6aa88d6026577b59f3658ff727
   languageName: node
   linkType: hard
 
@@ -9525,6 +10654,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"timezone-groups@npm:^0.10.4":
+  version: 0.10.4
+  resolution: "timezone-groups@npm:0.10.4"
+  checksum: 10c0/87421706ea3fa3cb382cf3e81e3f45dcb7a7b3a44ed6a128afe63fb21b55ae6c527c6a98cec4e743c0de90b62c5e4934b84a16a25f30d66317276563740e8177
+  languageName: node
+  linkType: hard
+
 "tinycolor2@npm:^1.4.1":
   version: 1.6.0
   resolution: "tinycolor2@npm:1.6.0"
@@ -9606,6 +10742,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-essentials@npm:10.0.3":
+  version: 10.0.3
+  resolution: "ts-essentials@npm:10.0.3"
+  peerDependencies:
+    typescript: ">=4.5.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/1bbad8241d8db1ebe4b2eb8f3c984b879de24b14ea42010fcbbc71d9a61a4e3ccd95f7a22c8c0709e2cad578fe1722012e9fbf74420a2ca3fc840565d0b8eb9d
+  languageName: node
+  linkType: hard
+
 "ts-essentials@npm:9.4.1":
   version: 9.4.1
   resolution: "ts-essentials@npm:9.4.1"
@@ -9653,6 +10801,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.8.1":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  languageName: node
+  linkType: hard
+
 "tunnel-agent@npm:^0.6.0":
   version: 0.6.0
   resolution: "tunnel-agent@npm:0.6.0"
@@ -9696,6 +10851,13 @@ __metadata:
   version: 1.4.0
   resolution: "type-fest@npm:1.4.0"
   checksum: 10c0/a3c0f4ee28ff6ddf800d769eafafcdeab32efa38763c1a1b8daeae681920f6e345d7920bf277245235561d8117dab765cb5f829c76b713b4c9de0998a5397141
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^4.30.1":
+  version: 4.41.0
+  resolution: "type-fest@npm:4.41.0"
+  checksum: 10c0/f5ca697797ed5e88d33ac8f1fec21921839871f808dc59345c9cf67345bfb958ce41bd821165dbf3ae591cedec2bf6fe8882098dfdd8dc54320b859711a2c1e4
   languageName: node
   linkType: hard
 
@@ -9893,6 +11055,15 @@ __metadata:
     querystringify: "npm:^2.1.1"
     requires-port: "npm:^1.0.0"
   checksum: 10c0/bd5aa9389f896974beb851c112f63b466505a04b4807cea2e5a3b7092f6fbb75316f0491ea84e44f66fed55f1b440df5195d7e3a8203f64fcefa19d182f5be87
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.0.0":
+  version: 1.5.0
+  resolution: "use-sync-external-store@npm:1.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/1b8663515c0be34fa653feb724fdcce3984037c78dd4a18f68b2c8be55cc1a1084c578d5b75f158d41b5ddffc2bf5600766d1af3c19c8e329bb20af2ec6f52f4
   languageName: node
   linkType: hard
 
@@ -10299,12 +11470,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xlsx@https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz":
-  version: 0.20.2
-  resolution: "xlsx@https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
+"xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz":
+  version: 0.20.3
+  resolution: "xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
   bin:
     xlsx: ./bin/xlsx.njs
-  checksum: 10c0/664dff22e5ecd83d595f34e00ac90ee852d16e45b72385ada54291551b808c6848b166fb395f5e35249ca976a5b5d514e793ccbcc0a611b87a600ae4024d605a
+  checksum: 10c0/eb20749e56ffa23ffc4a5a6fd983524e0406308e53992e24112424de9f30ec64d7dd80e8e56363e39c3853687f7b4151f97a6f5373050b23c0c2758796803b6b
   languageName: node
   linkType: hard
 
@@ -10337,7 +11508,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xss@npm:^1.0.14":
+"xss@npm:^1.0.14, xss@npm:^1.0.15":
   version: 1.0.15
   resolution: "xss@npm:1.0.15"
   dependencies:


### PR DESCRIPTION
This should be the same set of changes as the previous set of PRs, but without the mysterious webpack 5.94 reference in the yarn.lock file. Hopefully it will build correctly!

Note that the underlying issue here is that somewhere between webpack 5.90 and 5.94 a breaking change to package resolution for plugins was introduced, and it can no longer find plugins in `node_modules` in some situations where it could before. Generally it seems to be required that they exist at the same level as the copy of webpack being run, and it can't pull them out from references in other packages anymore.