### PR TITLE
Fixed typo and added link to instructions in README.md 

### DIFF
--- a/libraries/eagle-view-viewer/README.md
+++ b/libraries/eagle-view-viewer/README.md
@@ -1,7 +1,9 @@
-# Eagle View Embedded Explorer
+# EagleView Embedded Explorer
 
-The `Eagle View` component in this library renders an [Embedded Explorer](https://embedded-explorer.eagleview.com/static/docs/) control.
+The `EagleView` component in this library renders an [Embedded Explorer](https://embedded-explorer.eagleview.com/static/docs/) control.
 
 The [component](src/components/EmbeddedExplorer/EagleView.tsx) initializes the embedded explorer and acts as a wrapper so it can be placed anywhere in a VertiGIS Studio Web application. It will sync the current position of the Web applications map with the location of the embedded explorer so that changes in either map will be reflected int the other view.
 
-The VertiGIS Studio Map component in the sample instantiates a sample VertiGIS Studio Web application with a Eagle View component pre-configured.
+The VertiGIS Studio Map component in the sample instantiates a sample VertiGIS Studio Web application with an EagleView component pre-configured.
+
+Please [see this article](https://support.vertigis.com/hc/en-us/articles/28311610134418-Add-Eagleview-Explorer-to-VertiGIS-Studio-Web) for instructions on deploying the EagleView Embedded Explorer component for VertiGIS Studio Web. 


### PR DESCRIPTION
Removed space in Eagle View to match product name.
Added link to article with deployment instructions on support site.