### PR TITLE
fix: workaround for css issue

### DIFF
--- a/viewer/build/index.html
+++ b/viewer/build/index.html
@@ -131,6 +131,11 @@
                                 appConfig,
                                 layout: getAbsoluteUrl("layout.xml"),
                                 libraries: libs.map(lib => lib.default),
+                            }).then(() => {
+                                const loader = document.querySelector(".vgs-web-library-viewer-loading");
+                                if (loader) {
+                                    loader.style.display = "none";
+                                }
                             });
                         })
                     });
@@ -138,6 +143,10 @@
             }
 
             function injectIframe() {
+                const loader = document.querySelector(".vgs-web-library-viewer-loading");
+                if (loader) {
+                    loader.style.display = "flex";
+                }
                 const iframe = document.createElement("iframe");
                 iframe.name = "viewer";
                 iframe.id = "vgs_web_library_viewer_iframe";


### PR DESCRIPTION
Bizarre issue where adding content to the "chat window" pushes everything up off the top of the screen by an equivalent amount. This component is inside 2 nested shadow DOMs so there's no way this should be possible but it happens.

Fix is to hide the loading spinner, as if there is nothing pushed offscreen this doesn't happen. 
This only affects the production build, or `yarn preview` in a local copy.